### PR TITLE
Fixes Horizon issue by binding to resolving instead of extending

### DIFF
--- a/Providers/IdentificationProvider.php
+++ b/Providers/IdentificationProvider.php
@@ -29,14 +29,12 @@ class IdentificationProvider extends DriverProvider
 
     public function boot()
     {
-        $this->app->extend('queue', function (QueueManager $queue) {
+        $this->app->resolving(QueueManager::class, function ($queue) {
             // Store tenant key and identifier on job payload when a tenant is identified.
             $queue->createPayloadUsing($this->app->make(Middleware\SaveTenantOnQueuePayload::class));
 
             // Resolve any tenant related meta data on job and allow resolving of tenant.
             $queue->before($this->app->make(Middleware\ReadTenantFromQueuePayload::class));
-
-            return $queue;
         });
     }
 }


### PR DESCRIPTION
Fixes issue `Call to undefined method Illuminate\Queue\RedisQueue::readyNow()` with Laraven Horizon


Original issue here:
https://github.com/tenancy/multi-tenant/commit/e0a564356e0d97e8f301953712deb0e8e4650d88#comments